### PR TITLE
[Fix] Re-Organize python SDK methods to rust conventions

### DIFF
--- a/sdk/src/account/address.rs
+++ b/sdk/src/account/address.rs
@@ -29,20 +29,6 @@ use std::{
 #[derive(Clone)]
 pub struct Address(AddressNative);
 
-impl Address {
-    pub fn from_native(address: AddressNative) -> Self {
-        Self(address)
-    }
-}
-
-impl Deref for Address {
-    type Target = AddressNative;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 #[pymethods]
 impl Address {
     /// Reads in an account address string.
@@ -50,6 +36,12 @@ impl Address {
     fn from_string(s: &str) -> anyhow::Result<Self> {
         let address = FromStr::from_str(s)?;
         Ok(Self(address))
+    }
+
+    /// Returns the address as a base58 string.
+    #[allow(clippy::inherent_to_string)]
+    fn to_string(&self) -> String {
+        self.0.to_string()
     }
 
     fn __str__(&self) -> String {
@@ -64,5 +56,19 @@ impl Address {
         let mut hasher = DefaultHasher::new();
         self.0.hash(&mut hasher);
         hasher.finish()
+    }
+}
+
+impl Deref for Address {
+    type Target = AddressNative;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<AddressNative> for Address {
+    fn from(address: AddressNative) -> Self {
+        Self(address)
     }
 }

--- a/sdk/src/account/compute_key.rs
+++ b/sdk/src/account/compute_key.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Aleo SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::types::ComputeKeyNative;
+use crate::{types::ComputeKeyNative, Address};
 
 use pyo3::prelude::*;
 
@@ -23,22 +23,13 @@ use std::ops::Deref;
 #[pyclass(frozen)]
 pub struct ComputeKey(ComputeKeyNative);
 
-impl ComputeKey {
-    pub fn from_native(compute_key: ComputeKeyNative) -> Self {
-        Self(compute_key)
-    }
-}
-
-impl Deref for ComputeKey {
-    type Target = ComputeKeyNative;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 #[pymethods]
 impl ComputeKey {
+    /// Returns the address from the compute key.
+    fn address(&self) -> Address {
+        Address::from(self.0.to_address())
+    }
+
     /// Returns the signature public key.
     fn pk_sig(&self) -> String {
         self.0.pk_sig().to_string()
@@ -52,5 +43,19 @@ impl ComputeKey {
     /// Returns a reference to the PRF secret key.
     fn sk_prf(&self) -> String {
         self.0.sk_prf().to_string()
+    }
+}
+
+impl Deref for ComputeKey {
+    type Target = ComputeKeyNative;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<ComputeKeyNative> for ComputeKey {
+    fn from(compute_key: ComputeKeyNative) -> Self {
+        Self(compute_key)
     }
 }

--- a/sdk/src/account/mod.rs
+++ b/sdk/src/account/mod.rs
@@ -51,15 +51,14 @@ impl Account {
     /// Generates a new account using a cryptographically secure random number generator
     #[new]
     fn new() -> Self {
-        let private_key = PrivateKey::random();
-        Self::from_private_key(private_key)
+        Self::from(PrivateKey::new())
     }
 
     /// Creates a new account from the given private key.
     #[staticmethod]
     fn from_private_key(private_key: PrivateKey) -> Self {
         let view_key = private_key.view_key();
-        let address = private_key.address();
+        let address = private_key.address().unwrap();
         Self {
             private_key,
             view_key,
@@ -69,7 +68,7 @@ impl Account {
 
     /// Returns an account private key.
     fn private_key(&self) -> PrivateKey {
-        self.private_key.clone()
+        self.private_key
     }
 
     /// Returns an account view key.
@@ -93,8 +92,8 @@ impl Account {
     }
 
     /// Decrypts a record ciphertext with a view key
-    fn decrypt(&self, cipherrecord: &RecordCiphertext) -> anyhow::Result<RecordPlaintext> {
-        cipherrecord.decrypt(&self.view_key)
+    fn decrypt(&self, record_ciphertext: &RecordCiphertext) -> anyhow::Result<RecordPlaintext> {
+        record_ciphertext.decrypt(&self.view_key)
     }
 
     /// Determines whether the record belongs to the account.
@@ -117,5 +116,11 @@ impl Account {
         "account".hash(&mut hasher);
         self.private_key.hash(&mut hasher);
         hasher.finish()
+    }
+}
+
+impl From<PrivateKey> for Account {
+    fn from(private_key: PrivateKey) -> Self {
+        Self::from_private_key(private_key)
     }
 }

--- a/sdk/src/coinbase/prover_solution.rs
+++ b/sdk/src/coinbase/prover_solution.rs
@@ -46,7 +46,7 @@ impl ProverSolution {
 
     /// Returns the address of the prover.
     fn address(&self) -> Address {
-        Address::from_native(self.0.address())
+        Address::from(self.0.address())
     }
 
     /// Returns `true` if the prover solution is valid.

--- a/sdk/src/coinbase/puzzle.rs
+++ b/sdk/src/coinbase/puzzle.rs
@@ -33,7 +33,7 @@ impl CoinbasePuzzle {
     /// Returns the coinbase verifying key.
     fn verifying_key(&self) -> anyhow::Result<CoinbaseVerifyingKey> {
         let verifying_key = self.0.coinbase_verifying_key().clone();
-        Ok(CoinbaseVerifyingKey::from_native(verifying_key))
+        Ok(CoinbaseVerifyingKey::from(verifying_key))
     }
 
     #[classattr]

--- a/sdk/src/coinbase/verifying_key.rs
+++ b/sdk/src/coinbase/verifying_key.rs
@@ -23,8 +23,11 @@ use std::ops::Deref;
 #[pyclass(frozen)]
 pub struct CoinbaseVerifyingKey(CoinbaseVerifyingKeyNative);
 
-impl CoinbaseVerifyingKey {
-    pub fn from_native(key: CoinbaseVerifyingKeyNative) -> Self {
+#[pymethods]
+impl CoinbaseVerifyingKey {}
+
+impl From<CoinbaseVerifyingKeyNative> for CoinbaseVerifyingKey {
+    fn from(key: CoinbaseVerifyingKeyNative) -> Self {
         Self(key)
     }
 }
@@ -36,6 +39,3 @@ impl Deref for CoinbaseVerifyingKey {
         &self.0
     }
 }
-
-#[pymethods]
-impl CoinbaseVerifyingKey {}

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -19,7 +19,8 @@ use snarkvm::prelude::coinbase::{
     CoinbasePuzzle, CoinbaseVerifyingKey, EpochChallenge, ProverSolution,
 };
 use snarkvm::prelude::{
-    Address, Ciphertext, ComputeKey, Plaintext, PrivateKey, Record, Signature, ViewKey,
+    Address, Ciphertext, ComputeKey, Identifier, Plaintext, PrivateKey, ProgramID, Record,
+    Signature, ViewKey,
 };
 
 // Account types
@@ -31,6 +32,10 @@ pub type ViewKeyNative = ViewKey<CurrentNetwork>;
 
 // Network types
 pub type CurrentNetwork = Testnet3;
+
+// Program Types
+pub type IdentifierNative = Identifier<CurrentNetwork>;
+pub type ProgramIDNative = ProgramID<CurrentNetwork>;
 
 // Record types
 pub type CiphertextNative = Ciphertext<CurrentNetwork>;


### PR DESCRIPTION
## Motivation

This PR re-organize the python methods to rust idioms and makes the naming more consistent with the Javascript SDK