### PR TITLE
[mainnet] Add signing/verifying Aleo values

### DIFF
--- a/sdk/docs/source/examples.rst
+++ b/sdk/docs/source/examples.rst
@@ -44,6 +44,18 @@ Working with signatures
     >>> restored = aleo.Signature.from_string(serialized)
     >>> assert account.verify(restored, message)
 
+Working with signatures using Aleo values
+***********************
+
+.. doctest::
+
+    >>> account = aleo.Account()
+    >>> message = '5field'
+    >>> signature = account.sign_value(message)
+    >>> serialized = str(signature)
+    >>> restored = aleo.Signature.from_string(serialized)
+    >>> assert account.verify_value(restored, message)
+
 
 Calling a **transfer_public** function
 **************************************

--- a/sdk/python/test.py
+++ b/sdk/python/test.py
@@ -50,6 +50,17 @@ class TestAleo(unittest.TestCase):
         self.assertFalse(signature.verify(address, bad_message))
         self.assertEqual(signature, aleo.Signature.from_string(c_signature))
 
+    def test_signature_verify_value(self):
+        address = aleo.Address.from_string(
+            "aleo184vuwr5u7u0ha5f5k44067dd2uaqewxx6pe5ltha5pv99wvhfqxqv339h4")
+        c_signature = "sign1m9jrzpea7c8gdd0q7fp7pwszy6ar4du5p03aj8798c7pvwur9qqfhakcuf0xqelct6u8qylr0tkqwt46kngtg7capdlj6qeqkqevyqnavkjwgtm3t90lvxdrjjl07td0k4w5sysm7w22lfhfkqgdk690pcu5an22wssu4q6d3754cljxugdnrnccneldp79m3j5drzxs0s4sx2u5zze"
+        signature = aleo.Signature.from_string(c_signature)
+        message = "5field"
+        bad_message = "5u8"
+        self.assertTrue(signature.verify_value(address, message))
+        self.assertFalse(signature.verify_value(address, bad_message))
+        self.assertEqual(signature, aleo.Signature.from_string(c_signature))
+
     def test_account_sanity(self):
         private_key = aleo.PrivateKey.from_string(
             "APrivateKey1zkp3dQx4WASWYQVWKkq14v3RoQDfY2kbLssUj7iifi1VUQ6")
@@ -65,6 +76,14 @@ class TestAleo(unittest.TestCase):
         self.assertTrue(account.verify(signature, message))
         self.assertFalse(account.verify(signature, bad_message))
         self.assertTrue(signature.verify(account.address(), message))
+
+        message_value = "5field"
+        bad_message_value = "5u8"
+        signature_value = account.sign_value(message_value)
+
+        self.assertTrue(account.verify_value(signature_value, message_value))
+        self.assertFalse(account.verify_value(signature_value, bad_message_value))
+        self.assertTrue(signature_value.verify_value(account.address(), message_value))
 
     def test_encrypt_decrypt_sk(self):
         private_key = aleo.PrivateKey.from_string(

--- a/sdk/src/account/mod.rs
+++ b/sdk/src/account/mod.rs
@@ -92,9 +92,19 @@ impl Account {
         self.private_key.sign(message)
     }
 
+    /// Returns a signature for the given message (as an aleo value)
+    fn sign_value(&self, value: &str) -> anyhow::Result<Signature> {
+        self.private_key.sign_value(value)
+    }
+
     /// Verifies the signature of the given message.
     fn verify(&self, signature: &Signature, message: &[u8]) -> bool {
         signature.verify(&self.address, message)
+    }
+
+    /// Verifies the signature of the given value.
+    fn verify_value(&self, signature: &Signature, value: &str) -> bool {
+        signature.verify_value(&self.address, value)
     }
 
     /// Decrypts a record ciphertext with a view key

--- a/sdk/src/account/private_key.rs
+++ b/sdk/src/account/private_key.rs
@@ -77,6 +77,11 @@ impl PrivateKey {
         Signature::sign(self, message)
     }
 
+    /// Returns a signature for the given message (as a field) using the private key.
+    pub fn sign_value(&self, value: &str) -> anyhow::Result<Signature> {
+        Signature::sign_value(self, value)
+    }
+
     /// Returns the signature secret key.
     fn sk_sig(&self) -> Scalar {
         self.0.sk_sig().into()


### PR DESCRIPTION
Same as #37 but for mainnet

### Description

Signing/verifying aleo values is present in the [snarkOS CLI](https://github.com/AleoHQ/snarkOS/pull/2909) and the [leo CLI](https://github.com/AleoHQ/leo/pull/27627). Verification is present in [leo](https://developer.aleo.org/leo/language/#signatures).

As Aleo does not natively support byte-encoded messages, this feature is necessary for generating signatures programmatically for Aleo/Leo programs. The original `sign` and `verify` functions have not been altered for backwards compatibility.

### Features

This PR add the following functions (where `5field` is a valid [Aleo value](https://developer.aleo.org/leo/language/#data-types-and-values)
- `Account.sign_value("5field")`
- `Account.verify_value(Signature, "5field")`
- `Signature.sign_value(PrivateKey, "5field")`
- `Signature.verify_value(Address, "5field")`
- `PrivateKey.sign_value("5field")`

These functions automatically convert the string value into an Aleo value, then the Aleo value into Fields, which can be signed/verified natively. This is in part to bring parity closer to the CLI implementations, but also so a `Value` would not need to be constructed for every sign/verify.

### Docs & Testing

Docs were updated to include a copy of the sign/verify function usage, but with `sign_value` and `verify_value`. Tests were also updated to include the new functions.

### Validation

Signatures produced by this code have additionally been tested against the following program on [Leo Playground](https://play.leo-lang.org/):

```rs
program helloworld_pq56kj9.aleo {
  transition main(public a: address, b: signature, c: field) -> bool {
      return b.verify(a, c);
  }
}
```

Signature generation:

```python
>>> import aleo
>>> key = aleo.PrivateKey.from_string('APrivateKey1zkp3dQx4WASWYQVWKkq14v3RoQDfY2kbLssUj7iifi1VUQ6')
>>> str(key.sign_value('5field'))
'sign1zfmsaxvjajwje6ekk00wd0kyjc6p3j9xmkhkmc79064ge26q7ypenhsmwuel4gzx2jfpgl0lw9vqln74ljvtr00zkum0z0pe7tvd7qravkjwgtm3t90lvxdrjjl07td0k4w5sysm7w22lfhfkqgdk690pcu5an22wssu4q6d3754cljxugdnrnccneldp79m3j5drzxs0s4sxwet8kv'
```

```sh
$ leo run main aleo184vuwr5u7u0ha5f5k44067dd2uaqewxx6pe5ltha5pv99wvhfqxqv339h4 sign1zfmsaxvjajwje6ekk00wd0kyjc6p3j9xmkhkmc79064ge26q7ypenhsmwuel
4gzx2jfpgl0lw9vqln74ljvtr00zkum0z0pe7tvd7qravkjwgtm3t90lvxdrjjl07td0k4w5sysm7w22lfhfkqgdk690pcu5an22wssu4q6d3754cljxugdnrnccneldp79m3j5drzxs0s4s
xwet8kv 5field
```
![image](https://github.com/AleoHQ/python-sdk/assets/4142480/c87a0de0-f51e-46d1-a5fd-fc1dbeddcbdd)
