### PR TITLE
ci: shield-swap-sdk release job, macos-15-intel runners, PyPI trusted publishing

### DIFF
--- a/.github/workflows/sdk-wheels.yml
+++ b/.github/workflows/sdk-wheels.yml
@@ -265,21 +265,68 @@ jobs:
           name: shield-swap-wheels-universal
           path: shield-swap-sdk/dist
 
-  release:
-    name: Release
+  # Publishing uses PyPI trusted publishing (OIDC) — no token secret. Each
+  # package has its own job because a pending publisher must be unique per
+  # (repo, workflow, environment): the job's environment name must exactly
+  # match the publisher registered on PyPI for that project. All three gate
+  # on every build job, and they release strictly in dependency order:
+  # abi -> sdk -> shield-swap (shield-swap-sdk requires aleo-sdk on PyPI).
+  release-abi:
+    name: Release aleo-contract-abi-generator
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [build, sdist, build-abi, sdist-abi, build-shield-swap]
+    environment: pypi-abi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: '*wheels-*'
+          pattern: 'abi-wheels-*'
           merge-multiple: true
           path: dist
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
-          args: --non-interactive --skip-existing dist/*
+          packages-dir: dist
+          skip-existing: true
+
+  release-sdk:
+    name: Release aleo-sdk
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [build, sdist, build-abi, sdist-abi, build-shield-swap, release-abi]
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: 'wheels-*'
+          merge-multiple: true
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          skip-existing: true
+
+  release-shield-swap:
+    name: Release shield-swap-sdk
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [build, sdist, build-abi, sdist-abi, build-shield-swap, release-sdk]
+    environment: pypi-shield-swap
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: 'shield-swap-wheels-*'
+          merge-multiple: true
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          skip-existing: true

--- a/.github/workflows/sdk-wheels.yml
+++ b/.github/workflows/sdk-wheels.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'sdk/**'
       - 'sdk-abi/**'
+      - 'shield-swap-sdk/**'
       - '.github/workflows/sdk-wheels.yml'
       - '.github/workflows/sdk.yml'
     branches:
@@ -16,6 +17,7 @@ on:
     paths:
       - 'sdk/**'
       - 'sdk-abi/**'
+      - 'shield-swap-sdk/**'
       - '.github/workflows/sdk-wheels.yml'
       - '.github/workflows/sdk.yml'
   workflow_dispatch:
@@ -227,11 +229,47 @@ jobs:
           name: abi-wheels-sdist
           path: sdk-abi/dist
 
+  # shield-swap-sdk is pure Python (hatchling): one universal wheel + sdist.
+  # Depends on the built aleo-sdk wheel so its hermetic suite runs against
+  # the exact artifact shipping in this release, not a PyPI version.
+  build-shield-swap:
+    name: shield-swap-build
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-linux-x86_64
+          path: sdk-dist
+      - name: Build wheel + sdist
+        run: |
+          pip install build
+          python -m build shield-swap-sdk --outdir shield-swap-sdk/dist
+      - name: Test against the built aleo-sdk wheel
+        run: |
+          pip install --find-links sdk-dist aleo-sdk
+          pip install --find-links shield-swap-sdk/dist "shield-swap-sdk[async,mcp]" pytest pytest-asyncio
+          cd shield-swap-sdk && python -m pytest
+      # Prove the installed wheel imports on its own, away from the source tree.
+      - name: Smoke test wheel
+        run: |
+          cd "$RUNNER_TEMP"
+          python -c "import aleo_shield_swap; print('shield-swap-sdk', aleo_shield_swap.__version__)"
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: shield-swap-wheels-universal
+          path: shield-swap-sdk/dist
+
   release:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [build, sdist, build-abi, sdist-abi]
+    needs: [build, sdist, build-abi, sdist-abi, build-shield-swap]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sdk-wheels.yml
+++ b/.github/workflows/sdk-wheels.yml
@@ -48,7 +48,7 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64
           - name: macos-x86_64
-            runner: macos-13
+            runner: macos-15-intel
             target: x86_64
           - name: macos-aarch64
             runner: macos-latest
@@ -157,7 +157,7 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64
           - name: macos-x86_64
-            runner: macos-13
+            runner: macos-15-intel
             target: x86_64
           - name: macos-aarch64
             runner: macos-latest


### PR DESCRIPTION
## What

Release-pipeline changes cherry-picked from `feat/shield-swap-sdk` (everything before these landed in #49's squash), plus the switch to PyPI trusted publishing:

1. **`build-shield-swap` job** — builds the pure-Python `shield-swap-sdk` universal wheel + sdist, installs the release's own `aleo-sdk` wheel (linux-x86_64 artifact) and runs the hermetic suite against it, smoke-tests the installed wheel away from the source tree, and uploads as `shield-swap-wheels-universal` (matches the release artifact globs). Also adds `shield-swap-sdk/**` to the workflow path filters, giving the package CI coverage.
2. **`macos-13` → `macos-15-intel`** — GitHub retired the macOS 13 image on 2025-12-04, so both `macos-x86_64` jobs queued forever (no runner ever picked them up). `macos-15-intel` is GitHub's designated Intel migration path (supported until Fall 2027).
3. **Trusted publishing (OIDC), one release job per package** — replaces the token-based `maturin upload` with `pypa/gh-action-pypi-publish` under `id-token: write`. No `PYPI_API_TOKEN` secret is needed or used. Pending publishers must be unique per (repo, workflow, environment), so each package publishes from its own job/environment, and releases run strictly in order:

| Job | Package | Environment | Artifacts |
|---|---|---|---|
| `release-abi` | `aleo-contract-abi-generator` | `pypi-abi` | `abi-wheels-*` |
| `release-sdk` | `aleo-sdk` | `pypi` | `wheels-*` |
| `release-shield-swap` | `shield-swap-sdk` | `pypi-shield-swap` | `shield-swap-wheels-*` |

`release-sdk` needs `release-abi`; `release-shield-swap` needs `release-sdk` (it declares `aleo-sdk>=0.2`); all three gate on every build job. `skip-existing: true` keeps partial-failure re-runs safe.

## Prerequisites already configured

Three pending publishers are registered on PyPI matching the table above (owner `ProvableHQ`, repo `python-sdk`, workflow `sdk-wheels.yml`). The GitHub environments auto-create on first use.

## Release flow after merge

```
git tag v0.2.0 && git push origin v0.2.0
```

The tag run builds everything, then publishes abi → sdk → shield-swap. This PR's own CI run doubles as the first live validation of the `macos-15-intel` runners.
