### PR TITLE
deps: migrate pyo3 0.20 → 0.29

### DIFF
--- a/sdk-abi/Cargo.lock
+++ b/sdk-abi/Cargo.lock
@@ -989,9 +989,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1255,15 +1255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,15 +1515,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -1832,38 +1814,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "anyhow",
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1871,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1883,13 +1860,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote 1.0.46",
  "syn 2.0.118",
 ]
@@ -3404,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -3708,12 +3684,6 @@ name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/sdk-abi/Cargo.toml
+++ b/sdk-abi/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-pyo3 = { version = "0.20.0", features = ["extension-module", "abi3-py37", "anyhow"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py38", "anyhow"] }
 serde_json = "1"
 leo-abi = { git = "https://github.com/ProvableHQ/leo", rev = "ba2c01722a48f84b4d90b93aeaf8305b7c03dbce", package = "leo-abi", features = ["aleo-bytecode"] }
 leo-ast = { git = "https://github.com/ProvableHQ/leo", rev = "ba2c01722a48f84b4d90b93aeaf8305b7c03dbce", package = "leo-ast" }

--- a/sdk-abi/pyproject.toml
+++ b/sdk-abi/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.2.0"
 description = "Python bindings for ABI generation from Aleo bytecode"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = []
 
 [tool.maturin]

--- a/sdk-abi/src/lib.rs
+++ b/sdk-abi/src/lib.rs
@@ -109,7 +109,7 @@ fn check_compatibility(
 }
 
 #[pymodule]
-fn _aleo_abi(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn _aleo_abi(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(generate_abi, m)?)?;
     m.add_function(wrap_pyfunction!(check_compatibility, m)?)?;
     Ok(())

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -916,9 +916,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1190,12 +1190,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "indoc"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "ipnet"
@@ -1638,6 +1632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,37 +1694,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "anyhow",
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
- "parking_lot",
+ "once_cell",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1732,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1744,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3282,9 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.12"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -3587,12 +3583,6 @@ name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-
-[[package]]
-name = "unindent"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "untrusted"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1"
 hex = "0.4"
 indexmap = "2.1.0"
 once_cell = "1.18.0"
-pyo3 = { version = "0.20.0", features = ["extension-module", "abi3-py37", "anyhow"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py38", "anyhow"] }
 rand = { version = "0.10" }
 serde = "1"
 serde_json = "1"

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -2,6 +2,7 @@
 name = "aleo-sdk"
 description = "Python SDK for building zero-knowledge apps and DeFi on the Aleo network"
 version = "0.2.0"
+requires-python = ">=3.8"
 readme = "Readme.md"
 license = {file = "LICENSE.md"}
 authors = [

--- a/sdk/python/tests/test_account_parity.py
+++ b/sdk/python/tests/test_account_parity.py
@@ -283,8 +283,8 @@ class TestViewKeyParity:
         pk = PrivateKey.random()
         vk = pk.view_key
         b = vk.bytes()
-        assert isinstance(b, list)
-        assert all(isinstance(x, int) for x in b)
+        assert isinstance(b, bytes)   # pyo3 0.23+: Vec<u8> maps to bytes
+        assert len(b) == 32
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -236,6 +236,6 @@ class TestBytesRoundTrips:
     def test_authorization_bytes_round_trip(self):
         auth = self._make_auth()
         raw = auth.bytes()
-        assert isinstance(raw, list)
-        auth2 = Authorization.from_bytes(bytes(raw))
+        assert isinstance(raw, bytes)  # pyo3 0.23+: Vec<u8> maps to bytes
+        auth2 = Authorization.from_bytes(raw)
         assert auth.to_json() == auth2.to_json()

--- a/sdk/python/tests/test_value_plaintext.py
+++ b/sdk/python/tests/test_value_plaintext.py
@@ -92,14 +92,14 @@ class TestPlaintextParity:
     def test_to_bytes_raw_le(self):
         p = Plaintext.from_string(PLAINTEXT_LITERAL)
         raw = p.to_bytes_raw_le()
-        assert isinstance(raw, list)
-        assert all(isinstance(x, int) for x in raw)
+        assert isinstance(raw, bytes)  # pyo3 0.23+: Vec<u8> maps to bytes
+        assert len(raw) > 0
 
     def test_to_bytes_raw_be(self):
         p = Plaintext.from_string(PLAINTEXT_LITERAL)
         raw = p.to_bytes_raw_be()
-        assert isinstance(raw, list)
-        assert all(isinstance(x, int) for x in raw)
+        assert isinstance(raw, bytes)  # pyo3 0.23+: Vec<u8> maps to bytes
+        assert len(raw) > 0
 
     def test_to_fields_roundtrip(self):
         p = Plaintext.from_string(STRUCT)

--- a/sdk/src/account/address.rs
+++ b/sdk/src/account/address.rs
@@ -34,7 +34,7 @@ use std::{
 };
 
 /// The Aleo address type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Address(AddressNative);
 

--- a/sdk/src/account/graph_key.rs
+++ b/sdk/src/account/graph_key.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 /// The account graph key used for record scanning.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct GraphKey(GraphKeyNative);
 

--- a/sdk/src/account/private_key.rs
+++ b/sdk/src/account/private_key.rs
@@ -34,7 +34,7 @@ use std::{
 };
 
 /// The Aleo private key type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct PrivateKey(PrivateKeyNative);
 

--- a/sdk/src/account/private_key_ciphertext.rs
+++ b/sdk/src/account/private_key_ciphertext.rs
@@ -35,7 +35,7 @@ use std::{
 };
 
 /// Private key encrypted into ciphertext using a secret.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct PrivateKeyCiphertext(CiphertextNative);
 

--- a/sdk/src/account/record.rs
+++ b/sdk/src/account/record.rs
@@ -99,7 +99,7 @@ impl From<RecordCiphertextNative> for RecordCiphertext {
 }
 
 /// A value(plaintext) stored in program record.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct RecordPlaintext(RecordPlaintextNative);
 

--- a/sdk/src/account/signature.rs
+++ b/sdk/src/account/signature.rs
@@ -31,7 +31,7 @@ use std::{
 };
 
 /// The Aleo signature type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Signature(SignatureNative);
 

--- a/sdk/src/account/text.rs
+++ b/sdk/src/account/text.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use std::ops::Deref;
 
-use pyo3::{exceptions::PyTypeError, prelude::*};
+use pyo3::{exceptions::PyTypeError, prelude::*, IntoPyObjectExt};
 
 use snarkvm::prelude::{
     compute_function_id, FromBits, FromBytes, FromFields, Network, ToBits, ToBitsRaw, ToBytes,
@@ -139,7 +139,7 @@ impl From<CiphertextNative> for Ciphertext {
 }
 
 /// The Aleo plaintext type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Plaintext(PlaintextNative);
 
@@ -339,7 +339,7 @@ impl Plaintext {
     /// - Literal(address/field/group/scalar/signature) → str
     /// - Struct → dict[str, <recursive>]
     /// - Array → list[<recursive>]
-    pub fn to_python(&self, py: Python<'_>) -> PyObject {
+    pub fn to_python(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         plaintext_to_pyobject(&self.0, py)
     }
 
@@ -373,32 +373,35 @@ impl From<Plaintext> for PlaintextNative {
     }
 }
 
-fn plaintext_to_pyobject(p: &PlaintextNative, py: Python<'_>) -> PyObject {
+fn plaintext_to_pyobject(p: &PlaintextNative, py: Python<'_>) -> PyResult<Py<PyAny>> {
     match p {
         PlaintextNative::Literal(lit, _) => match lit {
-            LiteralNative::Boolean(b) => (**b).into_py(py),
-            LiteralNative::U8(n) => (**n).into_py(py),
-            LiteralNative::U16(n) => (**n).into_py(py),
-            LiteralNative::U32(n) => (**n).into_py(py),
-            LiteralNative::U64(n) => (**n).into_py(py),
-            LiteralNative::U128(n) => (**n).into_py(py),
-            LiteralNative::I8(n) => (**n).into_py(py),
-            LiteralNative::I16(n) => (**n).into_py(py),
-            LiteralNative::I32(n) => (**n).into_py(py),
-            LiteralNative::I64(n) => (**n).into_py(py),
-            LiteralNative::I128(n) => (**n).into_py(py),
-            _ => lit.to_string().into_py(py),
+            LiteralNative::Boolean(b) => (**b).into_py_any(py),
+            LiteralNative::U8(n) => (**n).into_py_any(py),
+            LiteralNative::U16(n) => (**n).into_py_any(py),
+            LiteralNative::U32(n) => (**n).into_py_any(py),
+            LiteralNative::U64(n) => (**n).into_py_any(py),
+            LiteralNative::U128(n) => (**n).into_py_any(py),
+            LiteralNative::I8(n) => (**n).into_py_any(py),
+            LiteralNative::I16(n) => (**n).into_py_any(py),
+            LiteralNative::I32(n) => (**n).into_py_any(py),
+            LiteralNative::I64(n) => (**n).into_py_any(py),
+            LiteralNative::I128(n) => (**n).into_py_any(py),
+            _ => lit.to_string().into_py_any(py),
         },
         PlaintextNative::Struct(members, _) => {
             let dict = pyo3::types::PyDict::new(py);
             for (k, v) in members.iter() {
-                let _ = dict.set_item(k.to_string(), plaintext_to_pyobject(v, py));
+                dict.set_item(k.to_string(), plaintext_to_pyobject(v, py)?)?;
             }
-            dict.into_py(py)
+            dict.into_py_any(py)
         }
         PlaintextNative::Array(elems, _) => {
-            let list: Vec<PyObject> = elems.iter().map(|e| plaintext_to_pyobject(e, py)).collect();
-            list.into_py(py)
+            let list: Vec<Py<PyAny>> = elems
+                .iter()
+                .map(|e| plaintext_to_pyobject(e, py))
+                .collect::<PyResult<_>>()?;
+            list.into_py_any(py)
         }
     }
 }

--- a/sdk/src/account/view_key.rs
+++ b/sdk/src/account/view_key.rs
@@ -27,7 +27,7 @@ use std::{
 };
 
 /// The account view key used to decrypt records and ciphertext.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct ViewKey(ViewKeyNative);
 

--- a/sdk/src/algebra/boolean.rs
+++ b/sdk/src/algebra/boolean.rs
@@ -35,7 +35,7 @@ use std::{
 };
 
 /// The Aleo boolean type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Copy, Clone)]
 pub struct Boolean(BooleanNative);
 

--- a/sdk/src/algebra/field.rs
+++ b/sdk/src/algebra/field.rs
@@ -35,7 +35,7 @@ use std::{
 };
 
 /// The Aleo field type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Field(FieldNative);
 

--- a/sdk/src/algebra/group.rs
+++ b/sdk/src/algebra/group.rs
@@ -37,7 +37,7 @@ use std::{
 };
 
 /// The Aleo group type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Group(GroupNative);
 

--- a/sdk/src/algebra/integer.rs
+++ b/sdk/src/algebra/integer.rs
@@ -45,7 +45,7 @@ use std::{
 macro_rules! integer_unsigned {
     ($export_ty:ident, $native:ident, $machine:ident, $literal_variant:ident, $desc:literal) => {
         #[doc = concat!("The Aleo ", $desc, " type.")]
-        #[pyclass(frozen)]
+        #[pyclass(frozen, from_py_object)]
         #[derive(Copy, Clone)]
         pub struct $export_ty($native);
 
@@ -409,7 +409,7 @@ macro_rules! integer_unsigned {
 macro_rules! integer_signed {
     ($export_ty:ident, $native:ident, $machine:ident, $literal_variant:ident, $desc:literal) => {
         #[doc = concat!("The Aleo ", $desc, " type.")]
-        #[pyclass(frozen)]
+        #[pyclass(frozen, from_py_object)]
         #[derive(Copy, Clone)]
         pub struct $export_ty($native);
 

--- a/sdk/src/algebra/scalar.rs
+++ b/sdk/src/algebra/scalar.rs
@@ -39,7 +39,7 @@ use std::{
 };
 
 /// The Aleo scalar type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Scalar(ScalarNative);
 

--- a/sdk/src/credits/mod.rs
+++ b/sdk/src/credits/mod.rs
@@ -17,7 +17,7 @@
 use pyo3::prelude::*;
 
 /// The type represents the amount of Aleo credits.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone, Copy)]
 pub struct Credits(f64);
 
@@ -41,11 +41,11 @@ impl Credits {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 }
 
 /// The type represents the amount of Aleo microcredits.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone, Copy)]
 pub struct MicroCredits(u64);
 
@@ -65,7 +65,7 @@ impl MicroCredits {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 }
 
 impl From<u64> for MicroCredits {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -38,7 +38,7 @@ use programs::*;
 /// Python developers with zk (zero-knowledge) programming capabilities
 /// via the usage of Aleo's zkSnarks.
 /// Registers all classes into the module (shared by both network builds).
-fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Account>()?;
     m.add_class::<Address>()?;
     m.add_class::<Authorization>()?;
@@ -107,13 +107,13 @@ fn register(_py: Python, m: &PyModule) -> PyResult<()> {
 #[cfg(not(feature = "testnet"))]
 #[pymodule]
 #[pyo3(name = "_aleolib_mainnet")]
-fn aleolib_mainnet(py: Python, m: &PyModule) -> PyResult<()> {
-    register(py, m)
+fn aleolib_mainnet(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    register(m)
 }
 
 #[cfg(feature = "testnet")]
 #[pymodule]
 #[pyo3(name = "_aleolib_testnet")]
-fn aleolib_testnet(py: Python, m: &PyModule) -> PyResult<()> {
-    register(py, m)
+fn aleolib_testnet(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    register(m)
 }

--- a/sdk/src/network/mod.rs
+++ b/sdk/src/network/mod.rs
@@ -21,7 +21,7 @@ use pyo3::prelude::*;
 use snarkvm::prelude::Network as NetworkTrait;
 
 /// The type represents the current network.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Network;
 

--- a/sdk/src/programs/authorization.rs
+++ b/sdk/src/programs/authorization.rs
@@ -24,7 +24,7 @@ use pyo3::prelude::*;
 use snarkvm::prelude::{FromBytes, ToBytes};
 
 /// The Aleo authorization type.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct Authorization(AuthorizationNative);
 

--- a/sdk/src/programs/deployment.rs
+++ b/sdk/src/programs/deployment.rs
@@ -35,7 +35,7 @@ const DEVNODE_CERTIFICATE: &str =
 /// certificates, and (V9+) the program checksum and owner address.
 ///
 /// Produced by `Process.deploy`; consumed by `Transaction.from_deployment`.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Deployment(DeploymentNative);
 

--- a/sdk/src/programs/dynamic_record.rs
+++ b/sdk/src/programs/dynamic_record.rs
@@ -12,7 +12,7 @@ use std::{ops::Deref, str::FromStr};
 
 /// A fixed-size representation of an Aleo record that stores the Merkle root
 /// of the record data rather than the full data.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct DynamicRecord(DynamicRecordNative);
 
@@ -92,7 +92,7 @@ impl DynamicRecord {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 }
 
 impl Deref for DynamicRecord {

--- a/sdk/src/programs/execution.rs
+++ b/sdk/src/programs/execution.rs
@@ -22,7 +22,7 @@ use snarkvm::prelude::{FromBytes, ToBytes};
 use std::ops::Deref;
 
 /// The type represents a call to an Aleo program.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct Execution(ExecutionNative);
 

--- a/sdk/src/programs/execution_request.rs
+++ b/sdk/src/programs/execution_request.rs
@@ -32,7 +32,7 @@ use std::{ops::Deref, str::FromStr};
 /// Used by the delegated proving service: a `Request` is signed client-side and
 /// the server turns it into an `Authorization` via `Process::authorize_request`
 /// before proving.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct ExecutionRequest(RequestNative);
 
@@ -180,7 +180,7 @@ impl ExecutionRequest {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 }
 
 impl Deref for ExecutionRequest {

--- a/sdk/src/programs/fee.rs
+++ b/sdk/src/programs/fee.rs
@@ -22,7 +22,7 @@ use snarkvm::prelude::{FromBytes, ToBytes};
 use std::ops::Deref;
 
 /// The type represents a fee paid to the network, used for rejected transactions.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Fee(FeeNative);
 
@@ -103,7 +103,7 @@ impl Fee {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 }
 
 impl Deref for Fee {

--- a/sdk/src/programs/identifier.rs
+++ b/sdk/src/programs/identifier.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 /// The Aleo identifier type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct Identifier(IdentifierNative);
 

--- a/sdk/src/programs/literal.rs
+++ b/sdk/src/programs/literal.rs
@@ -28,7 +28,7 @@ use std::{
 };
 
 /// The literal type represents all supported types in snarkVM.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Literal(LiteralNative);
 

--- a/sdk/src/programs/locator.rs
+++ b/sdk/src/programs/locator.rs
@@ -29,7 +29,7 @@ use std::{
 };
 
 /// A locator is of the form `{program_id}/{resource}` (i.e. `howard.aleo/notify`).
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Locator(LocatorNative);
 

--- a/sdk/src/programs/metadata.rs
+++ b/sdk/src/programs/metadata.rs
@@ -38,7 +38,7 @@ fn make_metadata(
 }
 
 /// Metadata for an Aleo credits function's proving and verifying keys.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct Metadata {
     #[pyo3(get)]

--- a/sdk/src/programs/offline_query.rs
+++ b/sdk/src/programs/offline_query.rs
@@ -16,7 +16,7 @@ type StateRoot = <CurrentNetwork as Network>::StateRoot;
 
 /// An offline query object used to insert the global state root and state paths
 /// needed to create a valid inclusion proof offline.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OfflineQuery {
     block_height: u32,

--- a/sdk/src/programs/program.rs
+++ b/sdk/src/programs/program.rs
@@ -23,6 +23,7 @@ use crate::{
 use pyo3::{
     prelude::*,
     types::{PyDict, PyList},
+    IntoPyObjectExt,
 };
 use snarkvm::prelude::{EntryType, PlaintextType, ValueType};
 
@@ -88,7 +89,7 @@ impl Program {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 
     /// Returns true if the program contains a function with the given name.
     fn has_function(&self, function_name: &str) -> bool {
@@ -100,7 +101,7 @@ impl Program {
         &self,
         py: Python<'py>,
         function_name: &str,
-    ) -> anyhow::Result<PyObject> {
+    ) -> anyhow::Result<Py<PyAny>> {
         let id = IdentifierNative::from_str(function_name)?;
         let function = self
             .0
@@ -159,11 +160,11 @@ impl Program {
                 }
             }
         }
-        Ok(list.into_py(py))
+        Ok(list.into_py_any(py)?)
     }
 
     /// Returns a list of dicts describing each mapping in the program.
-    fn get_mappings<'py>(&self, py: Python<'py>) -> anyhow::Result<PyObject> {
+    fn get_mappings<'py>(&self, py: Python<'py>) -> anyhow::Result<Py<PyAny>> {
         let list = PyList::empty(py);
         for (name, mapping) in self.0.mappings().iter() {
             let d = PyDict::new(py);
@@ -172,7 +173,7 @@ impl Program {
             d.set_item("value_type", mapping.value().plaintext_type().to_string())?;
             list.append(d)?;
         }
-        Ok(list.into_py(py))
+        Ok(list.into_py_any(py)?)
     }
 
     /// Returns a dict describing the members of the given record type.
@@ -180,9 +181,9 @@ impl Program {
         &self,
         py: Python<'py>,
         record_name: &str,
-    ) -> anyhow::Result<PyObject> {
+    ) -> anyhow::Result<Py<PyAny>> {
         let d = record_members_dict(py, &self.0, record_name)?;
-        Ok(d.into_py(py))
+        Ok(d.into_py_any(py)?)
     }
 
     /// Returns a list of dicts describing the members of the given struct type.
@@ -190,9 +191,9 @@ impl Program {
         &self,
         py: Python<'py>,
         struct_name: &str,
-    ) -> anyhow::Result<PyObject> {
+    ) -> anyhow::Result<Py<PyAny>> {
         let list = struct_members_list(py, &self.0, struct_name)?;
-        Ok(list.into_py(py))
+        Ok(list.into_py_any(py)?)
     }
 
     /// Returns the address corresponding to this program's ID.
@@ -225,7 +226,7 @@ fn plaintext_input_to_dict<'py>(
     plaintext: &PlaintextType<CurrentNetwork>,
     visibility: Option<&str>,
     name: Option<&str>,
-) -> anyhow::Result<&'py PyDict> {
+) -> anyhow::Result<Bound<'py, PyDict>> {
     let d = PyDict::new(py);
     match plaintext {
         PlaintextType::Literal(lit) => {
@@ -277,7 +278,7 @@ fn record_members_dict<'py>(
     py: Python<'py>,
     program: &ProgramNative,
     record_name: &str,
-) -> anyhow::Result<&'py PyDict> {
+) -> anyhow::Result<Bound<'py, PyDict>> {
     let id = IdentifierNative::from_str(record_name)?;
     let record_type = program
         .get_record(&id)
@@ -311,7 +312,7 @@ fn struct_members_list<'py>(
     py: Python<'py>,
     program: &ProgramNative,
     struct_name: &str,
-) -> anyhow::Result<&'py PyList> {
+) -> anyhow::Result<Bound<'py, PyList>> {
     let id = IdentifierNative::from_str(struct_name)?;
     let struct_type = program
         .get_struct(&id)

--- a/sdk/src/programs/program_id.rs
+++ b/sdk/src/programs/program_id.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 /// A program ID is of the form `{name}.{network}`.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct ProgramID(ProgramIDNative);
 

--- a/sdk/src/programs/proof.rs
+++ b/sdk/src/programs/proof.rs
@@ -11,7 +11,7 @@ use snarkvm::prelude::{FromBytes, ToBytes};
 use std::{ops::Deref, str::FromStr};
 
 /// SNARK proof for verification of program execution.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Proof(ProofNative);
 
@@ -44,7 +44,7 @@ impl Proof {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 }
 
 impl Deref for Proof {

--- a/sdk/src/programs/proving_key.rs
+++ b/sdk/src/programs/proving_key.rs
@@ -24,7 +24,7 @@ use snarkvm::prelude::{FromBytes, ToBytes};
 use std::str::FromStr;
 
 /// The Aleo proving key type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct ProvingKey(ProvingKeyNative);
 
@@ -57,7 +57,7 @@ impl ProvingKey {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 
     // ---- Task 8 additions ----
 

--- a/sdk/src/programs/proving_request.rs
+++ b/sdk/src/programs/proving_request.rs
@@ -228,7 +228,7 @@ impl std::fmt::Display for ProvingRequestInner {
 /// Use `kind()` when handling a `ProvingRequest` of unknown variant (e.g. after
 /// deserialization). Variant-specific accessors raise if called on the wrong
 /// variant.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct ProvingRequest(ProvingRequestInner);
 
@@ -374,7 +374,7 @@ impl ProvingRequest {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 }
 
 impl From<ProvingRequestInner> for ProvingRequest {

--- a/sdk/src/programs/query.rs
+++ b/sdk/src/programs/query.rs
@@ -19,7 +19,7 @@ use crate::types::QueryNative;
 use pyo3::prelude::*;
 
 /// The Aleo query type.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct Query(QueryNative);
 
@@ -32,7 +32,7 @@ impl Query {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 }
 
 impl From<QueryNative> for Query {

--- a/sdk/src/programs/transaction.rs
+++ b/sdk/src/programs/transaction.rs
@@ -22,7 +22,7 @@ use crate::{
 
 use pyo3::{
     prelude::*,
-    types::{PyDict, PyList, PyTuple},
+    types::{PyDict, PyList},
 };
 use snarkvm::prelude::{FromBytes, ToBytes};
 
@@ -87,7 +87,7 @@ impl Transaction {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 
     // ---- new methods ----
 
@@ -141,15 +141,15 @@ impl Transaction {
     }
 
     /// Returns a list of (Field, RecordCiphertext) tuples for all records in the transaction.
-    fn records(&self, py: Python) -> PyObject {
+    fn records(&self, py: Python) -> Py<PyAny> {
         let list = PyList::empty(py);
         for (commitment, record) in self.0.records() {
             let f: Field = (*commitment).into();
             let rc: RecordCiphertext = record.clone().into();
-            let t = PyTuple::new(py, [f.into_py(py), rc.into_py(py)]);
+            let t = (f, rc).into_pyobject(py).unwrap();
             list.append(t).unwrap();
         }
-        list.into_py(py)
+        list.into_any().unbind()
     }
 
     /// Returns list of RecordPlaintext owned by view_key.
@@ -193,7 +193,7 @@ impl Transaction {
     }
 
     /// Returns a list of dicts with keys "program", "function", "verifying_key", "certificate".
-    fn verifying_keys(&self, py: Python) -> PyObject {
+    fn verifying_keys(&self, py: Python) -> Py<PyAny> {
         let list = PyList::empty(py);
         if let Some(deployment) = self.0.deployment() {
             for (fname, (vk, cert)) in deployment.verifying_keys() {
@@ -206,11 +206,11 @@ impl Transaction {
                 list.append(d).unwrap();
             }
         }
-        list.into_py(py)
+        list.into_any().unbind()
     }
 
     /// Returns a Python dict summarizing the transaction (id, type, fee fields).
-    fn summary(&self, py: Python) -> PyObject {
+    fn summary(&self, py: Python) -> Py<PyAny> {
         let d = PyDict::new(py);
         d.set_item("id", self.id()).unwrap();
         d.set_item("type", self.transaction_type()).unwrap();
@@ -218,7 +218,7 @@ impl Transaction {
         d.set_item("base_fee", self.base_fee_amount()).unwrap();
         d.set_item("priority_fee", self.priority_fee_amount())
             .unwrap();
-        d.into_py(py)
+        d.into_any().unbind()
     }
 }
 

--- a/sdk/src/programs/transition.rs
+++ b/sdk/src/programs/transition.rs
@@ -25,7 +25,8 @@ use crate::{
 
 use pyo3::{
     prelude::*,
-    types::{PyDict, PyList, PyTuple},
+    types::{PyDict, PyList},
+    IntoPyObjectExt,
 };
 use snarkvm::prelude::{compute_function_id, FromBytes, Network, ToBytes};
 
@@ -131,15 +132,15 @@ impl Transition {
     }
 
     /// Returns a list of (Field, RecordCiphertext) tuples for all records in this transition.
-    fn records(&self, py: Python) -> PyObject {
+    fn records(&self, py: Python) -> Py<PyAny> {
         let list = PyList::empty(py);
         for (commitment, record) in self.0.records() {
             let f: Field = (*commitment).into();
             let rc: RecordCiphertext = record.clone().into();
-            let t = PyTuple::new(py, [f.into_py(py), rc.into_py(py)]);
+            let t = (f, rc).into_pyobject(py).unwrap();
             list.append(t).unwrap();
         }
-        list.into_py(py)
+        list.into_any().unbind()
     }
 
     /// Returns list of RecordPlaintext owned by view_key.
@@ -166,23 +167,23 @@ impl Transition {
     }
 
     /// Returns a list of dicts representing the transition inputs.
-    fn inputs(&self, py: Python) -> PyObject {
+    fn inputs(&self, py: Python) -> Py<PyAny> {
         let list = PyList::empty(py);
         for input in self.0.inputs().iter() {
             let d = input_to_py_dict(py, input);
             list.append(d).unwrap();
         }
-        list.into_py(py)
+        list.into_any().unbind()
     }
 
     /// Returns a list of dicts representing the transition outputs.
-    fn outputs(&self, py: Python) -> PyObject {
+    fn outputs(&self, py: Python) -> Py<PyAny> {
         let list = PyList::empty(py);
         for output in self.0.outputs().iter() {
             let d = output_to_py_dict(py, output);
             list.append(d).unwrap();
         }
-        list.into_py(py)
+        list.into_any().unbind()
     }
 
     /// Decrypt private inputs/outputs using the transition view key.
@@ -245,7 +246,7 @@ impl Transition {
 
 // ---------- helpers ----------
 
-fn input_to_py_dict<'py>(py: Python<'py>, input: &InputNative) -> &'py PyDict {
+fn input_to_py_dict<'py>(py: Python<'py>, input: &InputNative) -> Bound<'py, PyDict> {
     let d = PyDict::new(py);
     match input {
         InputNative::Constant(id, plaintext) => {
@@ -295,7 +296,7 @@ fn input_to_py_dict<'py>(py: Python<'py>, input: &InputNative) -> &'py PyDict {
     d
 }
 
-fn output_to_py_dict<'py>(py: Python<'py>, output: &OutputNative) -> &'py PyDict {
+fn output_to_py_dict<'py>(py: Python<'py>, output: &OutputNative) -> Bound<'py, PyDict> {
     let d = PyDict::new(py);
     match output {
         OutputNative::Constant(id, plaintext) => {
@@ -377,13 +378,17 @@ fn output_to_py_dict<'py>(py: Python<'py>, output: &OutputNative) -> &'py PyDict
     d
 }
 
-fn future_to_py_dict<'py>(py: Python<'py>, future: &FutureNative, id: &FieldNative) -> &'py PyDict {
-    let arguments: Vec<PyObject> = future
+fn future_to_py_dict<'py>(
+    py: Python<'py>,
+    future: &FutureNative,
+    id: &FieldNative,
+) -> Bound<'py, PyDict> {
+    let arguments: Vec<Py<PyAny>> = future
         .arguments()
         .iter()
         .map(|arg| argument_to_py_object(py, arg, id))
         .collect();
-    let args_list = PyList::new(py, arguments);
+    let args_list = PyList::new(py, arguments).unwrap();
     let d = PyDict::new(py);
     d.set_item("type", "future").unwrap();
     d.set_item("id", id.to_string()).unwrap();
@@ -395,19 +400,19 @@ fn future_to_py_dict<'py>(py: Python<'py>, future: &FutureNative, id: &FieldNati
     d
 }
 
-fn argument_to_py_object(py: Python<'_>, arg: &ArgumentNative, id: &FieldNative) -> PyObject {
+fn argument_to_py_object(py: Python<'_>, arg: &ArgumentNative, id: &FieldNative) -> Py<PyAny> {
     match arg {
-        ArgumentNative::Plaintext(plaintext) => plaintext.to_string().into_py(py),
-        ArgumentNative::Future(future) => future_to_py_dict(py, future, id).into_py(py),
+        ArgumentNative::Plaintext(plaintext) => plaintext.to_string().into_py_any(py).unwrap(),
+        ArgumentNative::Future(future) => future_to_py_dict(py, future, id).into_any().unbind(),
         ArgumentNative::DynamicFuture(dynamic_future) => {
             if let Ok(future) = dynamic_future.to_future() {
-                future_to_py_dict(py, &future, id).into_py(py)
+                future_to_py_dict(py, &future, id).into_any().unbind()
             } else {
                 let d = PyDict::new(py);
                 d.set_item("type", "dynamic_future").unwrap();
                 d.set_item("checksum", dynamic_future.checksum().to_string())
                     .unwrap();
-                d.into_py(py)
+                d.into_any().unbind()
             }
         }
     }

--- a/sdk/src/programs/value.rs
+++ b/sdk/src/programs/value.rs
@@ -25,7 +25,7 @@ use pyo3::prelude::*;
 use std::str::FromStr;
 
 /// The Aleo value type to interact with a call to an Aleo program.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct Value(ValueNative);
 
@@ -133,7 +133,7 @@ impl Value {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 }
 
 impl From<ValueNative> for Value {

--- a/sdk/src/programs/verifying_key.rs
+++ b/sdk/src/programs/verifying_key.rs
@@ -23,7 +23,7 @@ use snarkvm::prelude::{FromBytes, ToBytes};
 use std::str::FromStr;
 
 /// The Aleo verifying key type.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct VerifyingKey(VerifyingKeyNative);
 
@@ -56,7 +56,7 @@ impl VerifyingKey {
     }
 
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 
     // ---- Task 7 additions ----
 


### PR DESCRIPTION
## What

Migrates both Rust crates from pyo3 0.20.0 to 0.29.0. Mechanical migration — no architecture or Python-API changes: the dual-network cdylib design, class surface, and method signatures are unchanged.

- Module registration → `Bound<'_, PyModule>` (0.21 Bound API)
- `PyObject` → `Py<PyAny>`; `into_py` → `IntoPyObject`/`into_py_any` (0.23 conversion traits)
- GIL-ref `&'py PyDict`/`PyList` helper returns → `Bound`
- pyclasses extracted by value opt into `#[pyclass(from_py_object)]` (upstream is making the automatic Clone-based `FromPyObject` opt-in; without this, methods taking owned pyclass args would break in a future pyo3)
- `abi3-py37` no longer exists → wheels are now `cp38-abi3`; both packages declare `requires-python >= 3.8`

## One deliberate behavior change

`Vec<u8>` returns (`bytes()", `to_bytes_raw_*`) now produce Python `bytes` instead of `list[int]` — pyo3 0.23+ specializes byte vectors. This is the Pythonic analog of the wasm SDK's `Uint8Array`; facade callers already wrapped these in `bytes(...)` so nothing downstream changes. `Vec<bool>`/`Vec<Field>` still map to lists. Tests updated accordingly.

## Verification

- Zero compile warnings; clippy clean on both mainnet and testnet feature sets
- Main SDK: 876 passed / 2 skipped; sdk-abi: 8 passed; shield-swap-sdk: 79 passed — all on release builds of the migrated extensions
- Shield-swap devnode lifecycle tier (exercises the unproven Execution/Fee/Deployment bindings end-to-end): 9/9 passed
- Unblocks the failing dependabot pyo3 bump (#sdk-abi)

Supersedes dependabot's partial sdk-abi bump. Also enables future free-threaded (no-GIL) Python support, which pyo3 0.23+ provides.