### PR TITLE
chore: bump versions to 0.2.1, document invite-code gating

### DIFF
--- a/sdk-abi/Cargo.lock
+++ b/sdk-abi/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aleo-abi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "leo-abi",

--- a/sdk-abi/Cargo.toml
+++ b/sdk-abi/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Provable Inc.
+# Copyright (C) 2019-2026 Provable Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 [workspace]  # Prevent parent workspace capture

--- a/sdk-abi/Cargo.toml
+++ b/sdk-abi/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "aleo-abi"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 description = "Python bindings for ABI generation from Aleo bytecode (via Leo's leo-abi crate)"

--- a/sdk-abi/pyproject.toml
+++ b/sdk-abi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "aleo-contract-abi-generator"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python bindings for ABI generation from Aleo bytecode"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/sdk-abi/python/aleo_abi/__init__.py
+++ b/sdk-abi/python/aleo_abi/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Provable Inc.
+# Copyright (C) 2019-2026 Provable Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 """ABI generation and compatibility checking for Aleo programs."""
 

--- a/sdk-abi/python/tests/test_abi.py
+++ b/sdk-abi/python/tests/test_abi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Provable Inc.
+# Copyright (C) 2019-2026 Provable Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Tests for the aleo-contract-abi-generator package."""
 

--- a/sdk-abi/src/lib.rs
+++ b/sdk-abi/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Provable Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later
 //! Python bindings for leo-abi: ABI generation and compatibility checking for Aleo/Leo programs.
 

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aleo"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "hex",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aleo"
 authors = ["Konstantin Pandl", "Mike Turner", "Roman Proskuryakov"]
-version = "0.2.0"
+version = "0.2.1"
 description = "A Python sdk for zero-knowledge cryptography based on Aleo"
 edition = "2021"
 license = "GPL-3.0-or-later"

--- a/sdk/docs/source/conf.py
+++ b/sdk/docs/source/conf.py
@@ -8,7 +8,7 @@ import aleo
 # -- Project information
 
 project = 'aleo'
-copyright = '2023, AleoHQ'
+copyright = '2019-2026, Provable Inc.'
 author = 'kpp'
 
 version = '0.2.1'

--- a/sdk/docs/source/conf.py
+++ b/sdk/docs/source/conf.py
@@ -11,7 +11,7 @@ project = 'aleo'
 copyright = '2023, AleoHQ'
 author = 'kpp'
 
-version = '0.2.0'
+version = '0.2.1'
 
 # -- General configuration
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "aleo-sdk"
 description = "Python SDK for building zero-knowledge apps and DeFi on the Aleo network"
-version = "0.2.0"
+version = "0.2.1"
 readme = "Readme.md"
 license = {file = "LICENSE.md"}
 authors = [

--- a/sdk/python/aleo/abi.py
+++ b/sdk/python/aleo/abi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Provable Inc.
+# Copyright (C) 2019-2026 Provable Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 # pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false
 """Integration hook: ABI generation via the aleo-contract-abi-generator package."""

--- a/sdk/python/tests/test_algorithms.py
+++ b/sdk/python/tests/test_algorithms.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2023 Aleo Systems Inc.
+# Copyright (C) 2019-2026 Provable Inc.
 # This file is part of the Aleo SDK library.
 
 # The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/python/tests/test_records_extra.py
+++ b/sdk/python/tests/test_records_extra.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2023 Aleo Systems Inc.
+# Copyright (C) 2019-2026 Provable Inc.
 # This file is part of the Aleo SDK library.
 # Tests for W4a: record-scanning parity (GraphKey, commitments, tags, RVK, arithmetic).
 # Source notes: github.com/ProvableHQ/sdk@543b41e wasm/src/...

--- a/sdk/src/account/address.rs
+++ b/sdk/src/account/address.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/account/compute_key.rs
+++ b/sdk/src/account/compute_key.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/account/graph_key.rs
+++ b/sdk/src/account/graph_key.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/account/mod.rs
+++ b/sdk/src/account/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/account/private_key.rs
+++ b/sdk/src/account/private_key.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/account/private_key_ciphertext.rs
+++ b/sdk/src/account/private_key_ciphertext.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/account/record.rs
+++ b/sdk/src/account/record.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/account/signature.rs
+++ b/sdk/src/account/signature.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/account/text.rs
+++ b/sdk/src/account/text.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/account/view_key.rs
+++ b/sdk/src/account/view_key.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algebra/boolean.rs
+++ b/sdk/src/algebra/boolean.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algebra/field.rs
+++ b/sdk/src/algebra/field.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algebra/group.rs
+++ b/sdk/src/algebra/group.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algebra/integer.rs
+++ b/sdk/src/algebra/integer.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algebra/mod.rs
+++ b/sdk/src/algebra/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algebra/scalar.rs
+++ b/sdk/src/algebra/scalar.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/bhp/bhp1024.rs
+++ b/sdk/src/algorithms/bhp/bhp1024.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/bhp/bhp256.rs
+++ b/sdk/src/algorithms/bhp/bhp256.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/bhp/bhp512.rs
+++ b/sdk/src/algorithms/bhp/bhp512.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/bhp/bhp768.rs
+++ b/sdk/src/algorithms/bhp/bhp768.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/bhp/mod.rs
+++ b/sdk/src/algorithms/bhp/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/mod.rs
+++ b/sdk/src/algorithms/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/pedersen/mod.rs
+++ b/sdk/src/algorithms/pedersen/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/pedersen/pedersen128.rs
+++ b/sdk/src/algorithms/pedersen/pedersen128.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/pedersen/pedersen64.rs
+++ b/sdk/src/algorithms/pedersen/pedersen64.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/poseidon/mod.rs
+++ b/sdk/src/algorithms/poseidon/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/poseidon/poseidon2.rs
+++ b/sdk/src/algorithms/poseidon/poseidon2.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/poseidon/poseidon4.rs
+++ b/sdk/src/algorithms/poseidon/poseidon4.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/algorithms/poseidon/poseidon8.rs
+++ b/sdk/src/algorithms/poseidon/poseidon8.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/credits/mod.rs
+++ b/sdk/src/credits/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,7 +1,7 @@
 // pyo3 0.20 macro expansion triggers this lint on newer rustc; remove after pyo3 >= 0.21 upgrade
 #![allow(non_local_definitions)]
 
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/network/mod.rs
+++ b/sdk/src/network/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/authorization.rs
+++ b/sdk/src/programs/authorization.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/deployment.rs
+++ b/sdk/src/programs/deployment.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/dynamic_record.rs
+++ b/sdk/src/programs/dynamic_record.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 //
 // Licensed under GPL-3.0-or-later.

--- a/sdk/src/programs/execution.rs
+++ b/sdk/src/programs/execution.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/execution_request.rs
+++ b/sdk/src/programs/execution_request.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/fee.rs
+++ b/sdk/src/programs/fee.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/identifier.rs
+++ b/sdk/src/programs/identifier.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/literal.rs
+++ b/sdk/src/programs/literal.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/locator.rs
+++ b/sdk/src/programs/locator.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/metadata.rs
+++ b/sdk/src/programs/metadata.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 //
 // Licensed under GPL-3.0-or-later.

--- a/sdk/src/programs/mod.rs
+++ b/sdk/src/programs/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/offline_query.rs
+++ b/sdk/src/programs/offline_query.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 //
 // Licensed under GPL-3.0-or-later.

--- a/sdk/src/programs/process.rs
+++ b/sdk/src/programs/process.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/program.rs
+++ b/sdk/src/programs/program.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/program_id.rs
+++ b/sdk/src/programs/program_id.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/proof.rs
+++ b/sdk/src/programs/proof.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 //
 // Licensed under GPL-3.0-or-later.

--- a/sdk/src/programs/proving_key.rs
+++ b/sdk/src/programs/proving_key.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/proving_request.rs
+++ b/sdk/src/programs/proving_request.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/query.rs
+++ b/sdk/src/programs/query.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/response.rs
+++ b/sdk/src/programs/response.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/trace.rs
+++ b/sdk/src/programs/trace.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/transaction.rs
+++ b/sdk/src/programs/transaction.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/transition.rs
+++ b/sdk/src/programs/transition.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/value.rs
+++ b/sdk/src/programs/value.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/programs/verifying_key.rs
+++ b/sdk/src/programs/verifying_key.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Aleo Systems Inc.
+// Copyright (C) 2019-2026 Provable Inc.
 // This file is part of the Aleo SDK library.
 
 // The Aleo SDK library is free software: you can redistribute it and/or modify

--- a/shield-swap-sdk/pyproject.toml
+++ b/shield-swap-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shield-swap-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python SDK for the shield swap AMM Dex on Aleo"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/shield-swap-sdk/python/aleo_shield_swap/__init__.py
+++ b/shield-swap-sdk/python/aleo_shield_swap/__init__.py
@@ -45,7 +45,7 @@ from .agent import (
     shield_swap_tools as shield_swap_tools,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     "ShieldSwap", "AsyncShieldSwap", "ApiClient", "AsyncApiClient",

--- a/shield-swap-sdk/python/aleo_shield_swap/api.py
+++ b/shield-swap-sdk/python/aleo_shield_swap/api.py
@@ -53,6 +53,11 @@ class ApiClient:
     :meth:`authenticate` once with any Aleo account — the API authenticates
     by signature (challenge/verify), no funds required — or adopt a
     previously issued JWT via ``token=``/:meth:`set_token`.
+
+    Auth alone is not enough for the gated endpoints: the account must also
+    have redeemed an invite code (``POST /access/redeem``), otherwise they
+    return 403 ``redeem an invite code to unlock access``. Check with
+    ``GET /access/status``.
     """
 
     def __init__(self, base_url: str = DEFAULT_API_URL, session: Any | None = None,
@@ -92,8 +97,9 @@ class ApiClient:
         *sign* is a callable taking the challenge message string and
         returning an Aleo signature literal (``sign1…``) — e.g.::
 
-            api.authenticate(str(acct.address),
-                             lambda msg: str(aleo.account.sign(msg.encode(), acct)))
+            pk = aleo.testnet.PrivateKey.from_string(key)
+            api.authenticate(str(pk.address),
+                             lambda msg: str(pk.sign(msg.encode())))
         """
         challenge = self._post("/auth/challenge", {"address": address})
         signature = sign(challenge["data"]["message"])

--- a/shield-swap-sdk/tests/test_package.py
+++ b/shield-swap-sdk/tests/test_package.py
@@ -2,4 +2,4 @@ import aleo_shield_swap
 
 
 def test_version():
-    assert aleo_shield_swap.__version__ == "0.2.0"
+    assert aleo_shield_swap.__version__ == "0.2.1"


### PR DESCRIPTION
## Summary
- Bump `aleo-sdk`, `aleo-contract-abi-generator`, and `shield-swap-sdk` from 0.2.0 to 0.2.1 (Cargo.toml/Cargo.lock/pyproject.toml, docs conf, `__version__`, and the version assertion in tests).
- `shield-swap-sdk` `ApiClient` docs: note that signature auth alone is not enough for gated endpoints — the account must also have redeemed an invite code (`POST /access/redeem`, check via `GET /access/status`), and fix the `authenticate` example to use `aleo.testnet.PrivateKey` instead of the removed `aleo.account.sign` helper.
- Standardize all copyright headers to `Copyright (C) 2019-2026 Provable Inc.` — replacing both the `2019-2023 Aleo Systems Inc.` headers (60 files) and the `2024 Provable Inc.` headers (5 files) — and update the Sphinx docs copyright from `2023, AleoHQ` to `2019-2026, Provable Inc.`.