### PR TITLE
fix(facade): exact credits/microcredits conversion

### DIFF
--- a/sdk/python/aleo/_facade_common.py
+++ b/sdk/python/aleo/_facade_common.py
@@ -5,9 +5,14 @@ in the compiled extension modules or the network client.
 """
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from decimal import Decimal, ROUND_DOWN
+from typing import Any, Protocol, Union, runtime_checkable
 
 _MICROCREDITS_PER_CREDIT: int = 1_000_000
+
+#: What a credits amount may be written as.  ``str`` and ``Decimal`` are exact;
+#: ``float`` is not (see :func:`credits_to_microcredits`).
+CreditsAmount = Union[str, int, Decimal, float]
 
 
 @runtime_checkable
@@ -46,8 +51,44 @@ class RecordProvider(Protocol):
         ...
 
 
-def credits_to_microcredits(credits: float | int) -> int:
-    """Convert a credits amount (float or int) to integer microcredits.
+def _to_decimal(credits: CreditsAmount) -> Decimal:
+    """Interpret a credits amount exactly.
+
+    A ``float`` has already lost the value the caller wrote — ``1.005`` is really
+    ``1.00499999999999989...`` — so it is routed through ``str()``, which yields
+    the shortest representation that round-trips, i.e. the literal as typed.
+    ``str``, ``int``, and ``Decimal`` are exact already.
+    """
+    if isinstance(credits, Decimal):
+        return credits
+    if isinstance(credits, int):
+        return Decimal(credits)
+    return Decimal(str(credits))
+
+
+def credits_to_microcredits(
+    credits: CreditsAmount, *, allow_rounding: bool = False
+) -> int:
+    """Convert a credits amount to integer microcredits, exactly.
+
+    Computed in decimal, never binary floating point: ``1.005`` credits is
+    1_005_000 microcredits, where a float multiply would truncate to 1_004_999
+    and silently lose value.  Pass *credits* as ``str`` or ``Decimal`` for full
+    exactness; a ``float`` is interpreted as the decimal literal it prints as.
+
+    Args:
+        credits: Credits amount — ``"1.005"``, ``Decimal("1.005")``, ``1``, or
+            ``1.005``.
+        allow_rounding: Permit input finer than one microcredit, truncating
+            toward zero.  Off by default so lost precision is an error rather
+            than a silent underpayment.
+
+    Returns:
+        The amount in microcredits.
+
+    Raises:
+        ValueError: If *credits* carries sub-microcredit precision and
+            *allow_rounding* is False, or is not a usable number.
 
     Examples
     --------
@@ -55,18 +96,46 @@ def credits_to_microcredits(credits: float | int) -> int:
     1000000
     >>> credits_to_microcredits(1.5)
     1500000
+    >>> credits_to_microcredits("1.005")
+    1005000
     """
-    return int(credits * _MICROCREDITS_PER_CREDIT)
+    try:
+        scaled = _to_decimal(credits) * _MICROCREDITS_PER_CREDIT
+    except (ArithmeticError, ValueError, TypeError) as exc:
+        raise ValueError(f"{credits!r} is not a valid credits amount") from exc
+    if not scaled.is_finite():
+        raise ValueError(f"{credits!r} is not a finite credits amount")
+    rounded = scaled.to_integral_value(rounding=ROUND_DOWN)
+    if scaled != rounded and not allow_rounding:
+        raise ValueError(
+            f"{credits!r} credits is {scaled} microcredits — finer than the "
+            "chain's smallest unit. Round it yourself, or pass "
+            "allow_rounding=True to truncate toward zero."
+        )
+    return int(rounded)
 
 
-def microcredits_to_credits(microcredits: int) -> float:
-    """Convert an integer microcredits amount to a credits float.
+def microcredits_to_credits(microcredits: int) -> Decimal:
+    """Convert integer microcredits to credits, exactly.
+
+    Returns a :class:`~decimal.Decimal` rather than a float: microcredits are a
+    ``u64``, and past 2**53 a float cannot even hold the integer, so a float
+    round-trip is not the identity.  Compares equal to the obvious float
+    (``microcredits_to_credits(1_500_000) == 1.5``), but mixing it into float
+    arithmetic raises — convert deliberately with ``float(...)`` if you want
+    that, accepting the precision loss.
+
+    Args:
+        microcredits: Amount in microcredits.
+
+    Returns:
+        The amount in credits, exact at any ``u64`` magnitude.
 
     Examples
     --------
     >>> microcredits_to_credits(1_000_000)
-    1.0
+    Decimal('1.000000')
     >>> microcredits_to_credits(1_500_000)
-    1.5
+    Decimal('1.500000')
     """
-    return microcredits / _MICROCREDITS_PER_CREDIT
+    return Decimal(int(microcredits)).scaleb(-6)

--- a/sdk/python/aleo/facade/async_client.py
+++ b/sdk/python/aleo/facade/async_client.py
@@ -32,10 +32,15 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+from decimal import Decimal
 from typing import Any, AsyncGenerator
 
 from .._client_common import AleoNetworkError
-from .._facade_common import credits_to_microcredits, microcredits_to_credits
+from .._facade_common import (
+    CreditsAmount,
+    credits_to_microcredits,
+    microcredits_to_credits,
+)
 from .._scanner_common import OwnedRecord, RecordNotFoundError
 from .errors import (
     ExecutionError,
@@ -1238,20 +1243,34 @@ class AsyncAleo:
 
     # ── Unit conversions (sync) ─────────────────────────────────────────────
 
-    def to_microcredits(self, credits: float | int) -> int:
-        """Convert a credits amount to integer microcredits.
+    def to_microcredits(
+        self, credits: CreditsAmount, *, allow_rounding: bool = False
+    ) -> int:
+        """Convert a credits amount to integer microcredits, exactly.
 
-        ``1 credit == 1_000_000 microcredits``
+        Local and synchronous.  See :meth:`Aleo.to_microcredits` — computed in
+        decimal, so ``1.005`` gives 1_005_000 rather than 1_004_999.
 
         Parameters
         ----------
         credits:
-            Credits amount as a float or integer (e.g. ``1.5``).
-        """
-        return credits_to_microcredits(credits)
+            Credits amount; ``str`` and ``Decimal`` are exact.
+        allow_rounding:
+            Permit input finer than one microcredit, truncating toward zero.
 
-    def from_microcredits(self, microcredits: int) -> float:
-        """Convert an integer microcredits amount to credits.
+        Raises
+        ------
+        ValueError
+            If *credits* is finer than a microcredit and *allow_rounding* is
+            False, or is not a usable number.
+        """
+        return credits_to_microcredits(credits, allow_rounding=allow_rounding)
+
+    def from_microcredits(self, microcredits: int) -> Decimal:
+        """Convert an integer microcredits amount to credits, exactly.
+
+        Local and synchronous.  Returns a :class:`~decimal.Decimal` — see
+        :meth:`Aleo.from_microcredits` for why a float will not do.
 
         Parameters
         ----------

--- a/sdk/python/aleo/facade/client.py
+++ b/sdk/python/aleo/facade/client.py
@@ -7,10 +7,15 @@ to later phases.
 """
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 
 from .._client_common import AleoNetworkError
-from .._facade_common import credits_to_microcredits, microcredits_to_credits
+from .._facade_common import (
+    CreditsAmount,
+    credits_to_microcredits,
+    microcredits_to_credits,
+)
 from .provider import HTTPProvider
 
 # AleoNetworkClient imported at runtime (avoid circular at module-level)
@@ -211,20 +216,41 @@ class Aleo:
 
     # ── Unit conversions ───────────────────────────────────────────────────
 
-    def to_microcredits(self, credits: float | int) -> int:
-        """Convert a credits amount to integer microcredits.
+    def to_microcredits(
+        self, credits: CreditsAmount, *, allow_rounding: bool = False
+    ) -> int:
+        """Convert a credits amount to integer microcredits, exactly.
 
-        ``1 credit == 1_000_000 microcredits``
+        ``1 credit == 1_000_000 microcredits``.  Computed in decimal, so
+        ``1.005`` gives 1_005_000 rather than the 1_004_999 a binary float
+        multiply would truncate to.
 
         Parameters
         ----------
         credits:
-            Credits amount as a float or integer (e.g. ``1.5``).
-        """
-        return credits_to_microcredits(credits)
+            Credits amount.  ``str`` and ``Decimal`` are exact; a ``float`` is
+            read as the decimal literal it prints as, so prefer ``"1.005"`` over
+            ``1.005`` when the amount comes from text.
+        allow_rounding:
+            Permit input finer than one microcredit, truncating toward zero.
+            Off by default, so precision loss raises instead of silently
+            underpaying.
 
-    def from_microcredits(self, microcredits: int) -> float:
-        """Convert an integer microcredits amount to credits.
+        Raises
+        ------
+        ValueError
+            If *credits* is finer than a microcredit and *allow_rounding* is
+            False, or is not a usable number.
+        """
+        return credits_to_microcredits(credits, allow_rounding=allow_rounding)
+
+    def from_microcredits(self, microcredits: int) -> Decimal:
+        """Convert an integer microcredits amount to credits, exactly.
+
+        Returns a :class:`~decimal.Decimal`, not a float — microcredits are a
+        ``u64`` and past 2**53 a float cannot hold the integer.  It compares
+        equal to the obvious float, but mixing it into float arithmetic raises;
+        call ``float(...)`` deliberately if you want that.
 
         Parameters
         ----------

--- a/sdk/python/tests/test_facade_client.py
+++ b/sdk/python/tests/test_facade_client.py
@@ -4,6 +4,8 @@ All tests are mocked — no live network required.
 """
 from __future__ import annotations
 
+from decimal import Decimal
+
 import pytest
 import responses as resp_lib
 
@@ -310,6 +312,54 @@ def test_unit_conversion_round_trip() -> None:
     a = Aleo(HTTPProvider(BASE))
     original = 2.25
     assert a.from_microcredits(a.to_microcredits(original)) == original
+
+
+# Precision: these amounts silently lost value when the conversion went
+# through binary floating point (1.005 truncated to 1_004_999), and a
+# microcredit round-trip was not the identity for ~1.4% of values.
+
+
+def test_to_microcredits_does_not_lose_a_microcredit() -> None:
+    a = Aleo(HTTPProvider(BASE))
+    # float * 1e6 lands on 1004999.9999999999; int() then truncates down
+    assert a.to_microcredits(1.005) == 1_005_000
+    assert a.to_microcredits("1.005") == 1_005_000
+    assert a.to_microcredits(Decimal("1.005")) == 1_005_000
+
+
+def test_to_microcredits_rejects_sub_microcredit_precision() -> None:
+    a = Aleo(HTTPProvider(BASE))
+    with pytest.raises(ValueError, match="finer than the chain"):
+        a.to_microcredits(0.9999999)
+    # opt in to the old truncating behaviour explicitly
+    assert a.to_microcredits(0.9999999, allow_rounding=True) == 999_999
+
+
+def test_to_microcredits_rejects_nonsense() -> None:
+    a = Aleo(HTTPProvider(BASE))
+    for bad in ("abc", float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            a.to_microcredits(bad)
+
+
+def test_from_microcredits_is_exact_past_float_range() -> None:
+    a = Aleo(HTTPProvider(BASE))
+    # microcredits are u64; beyond 2**53 a float cannot hold the integer
+    for micro in (2**53 + 1, 2**64 - 1):
+        assert a.to_microcredits(a.from_microcredits(micro)) == micro
+
+
+def test_microcredit_round_trip_is_identity() -> None:
+    a = Aleo(HTTPProvider(BASE))
+    # 2884 of these failed when from_microcredits returned a float
+    for micro in range(0, 5_000):
+        assert a.to_microcredits(a.from_microcredits(micro)) == micro
+
+
+def test_from_microcredits_still_compares_equal_to_float() -> None:
+    a = Aleo(HTTPProvider(BASE))
+    assert a.from_microcredits(1_500_000) == 1.5
+    assert float(a.from_microcredits(1_500_000)) == 1.5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`to_microcredits` and `from_microcredits` both went through binary floating point and lost value. This makes both exact.

**Stacked on #65** — base is `docs/docstring-coverage-and-invite-minting-removal`, because both PRs touch the docstrings of these same two facade methods. Merge #65 first; GitHub will retarget this to `feat/shield-swap-update` automatically.

## The bugs

**Inbound — silent underpayment.** `credits * 1_000_000` in float, then `int()` truncating *toward zero*:

```python
>>> aleo.to_microcredits(1.005)   # before
1004999                            # 1.005 * 1e6 == 1004999.9999999999
```

One microcredit lost on a completely ordinary amount, with no error. Sub-microcredit input disappeared entirely — `to_microcredits(0.9999999)` returned `999999`.

**Outbound — not representable.** `from_microcredits` returned a float, but microcredits are a `u64` and past 2**53 a float cannot hold the integer:

```python
>>> m = 2**64 - 1
>>> int(aleo.from_microcredits(m) * 1_000_000) - m   # before
1
```

**2884 of the first 200_000** microcredit values failed `micro -> credits -> micro` identity — about 1.4%.

## The fix

Both directions compute in `Decimal`.

Float input is routed through `str()`, which recovers the shortest representation that round-trips — the literal the caller actually wrote. That is what rescues `1.005`, since `Decimal(1.005)` would faithfully preserve the float's real value of `1.00499999999999989...` and stay wrong. `str` and `Decimal` input are exact already, so `to_microcredits("1.005")` is now the precise way to pass an amount that came from text or JSON.

Sub-microcredit precision **raises** `ValueError` naming the offending value, with `allow_rounding=True` to opt back into truncation. Losing value should be an error, not a default.

```python
>>> aleo.to_microcredits(1.005)
1005000
>>> aleo.to_microcredits("1.005")
1005000
>>> aleo.to_microcredits(0.9999999)
ValueError: 0.9999999 credits is 999999.9000000 microcredits — finer than the
chain's smallest unit. Round it yourself, or pass allow_rounding=True to
truncate toward zero.
>>> aleo.to_microcredits(0.9999999, allow_rounding=True)
999999
```

## Breaking change

`from_microcredits` returns `Decimal`, not `float`.

Equality and `float()` still work, so **all three pre-existing assertions pass unchanged**, including `from_microcredits(1_500_000) == 1.5`. What breaks is mixing the result into float arithmetic — `from_microcredits(x) * 0.5` raises `TypeError`, as does `json.dumps` of the result. Call `float(...)` deliberately if you want that, accepting the loss. The docstring says so.

This is the deliberate trade for exactness: `Decimal` is the correct type for money, and a float simply cannot represent the full `u64` range.

## Scope

Contained, and checked rather than assumed: these are user-facing convenience helpers **only**. No internal fee or amount path consumes them — the SDK is integer microcredits end to end — and shield-swap never calls them, working in raw base units throughout. So no transaction the SDK builds today was affected; only callers who used the helpers to compute an amount.

## Verification

| Gate | Result |
|---|---|
| `pytest python/tests -m "not slow"` (sdk) | 896 passed, 17 skipped (+6 new) |
| `pyright` strict (sdk) | 0 errors, 0 warnings |
| `pytest` (shield-swap) | 174 passed — unaffected |

The 6 new tests pin exactly what was broken: the `1.005` class across `float`/`str`/`Decimal`, the `ValueError` and its escape hatch, NaN/inf/garbage rejection, exactness at `2**53 + 1` and `u64` max, identity across a 5000-value sweep, and that float comparison still holds.
